### PR TITLE
Comment back on pull request when it's closed/merged

### DIFF
--- a/locking/locking.go
+++ b/locking/locking.go
@@ -56,7 +56,6 @@ func (c *Client) Unlock(key string) (*models.ProjectLock, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return c.backend.Unlock(project, env)
 }
 

--- a/server/plan_executor.go
+++ b/server/plan_executor.go
@@ -27,7 +27,7 @@ type PlanExecutor struct {
 	terraform             *TerraformClient
 	githubCommentRenderer *GithubCommentRenderer
 	lockingClient         *locking.Client
-	// LockURL is a function that given a lock id will return a url for detail view
+	// LockURL is a function that given a lock id will return the url to view that lock
 	LockURL     func(id string) (url string)
 	planBackend plan.Backend
 }


### PR DESCRIPTION
Merge #42 first.

- [X] return locks from unlock/unlockbypull calls
- [x] create `DeletePlansByPull` and `DeletePlan` methods to clean up plans on apply/pull closed/errors
- [x] delete locks and plans on pull closed
- [x] comment back on pull

Comment for a single env:

> Locks and plans deleted for the projects and environments modified in this pull request:
> 
> - path: `lkysow/atlantis-terraform-test/.` environment: `staging`

Comment for multiple envs:

> Locks and plans deleted for the projects and environments modified in this pull request:
> 
> - path: `lkysow/atlantis-terraform-test/.` environments: `production`, `staging`

Fixes #31 

Changes
* for locking ,`Unlock` and `UnlockByPull` now return what was unlocked
* new functions to delete plans
* new `pull_closed_executor` that handles dealing with the closed pull