### PR TITLE
Allow atlantis to be called by the name of the api user

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"strings"
+
 	"github.com/hootsuite/atlantis/server"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -46,7 +48,7 @@ var stringFlags = []stringFlag{
 	},
 	{
 		name:        configFlag,
-		description: "Config file.",
+		description: "Path to config file.",
 	},
 	{
 		name:        dataDirFlag,
@@ -122,7 +124,7 @@ var serverCmd = &cobra.Command{
 	Long: `Start the atlantis server
 
 Flags can also be set in a yaml config file (see --` + configFlag + `).
-Config values are overridden by environment variables which in turn are overridden by flags.`,
+Config file values are overridden by environment variables which in turn are overridden by flags.`,
 	SilenceUsage: true,
 
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -147,6 +149,7 @@ Config values are overridden by environment variables which in turn are overridd
 		if err := setAtlantisURL(&config); err != nil {
 			return err
 		}
+		sanitizeGithubUser(&config)
 
 		// config looks good, start the server
 		server, err := server.NewServer(config)
@@ -208,4 +211,9 @@ func setAtlantisURL(config *server.ServerConfig) error {
 		config.AtlantisURL = fmt.Sprintf("http://%s:%d", hostname, config.Port)
 	}
 	return nil
+}
+
+// sanitizeGithubUser trims @ from the front of the username if it exists
+func sanitizeGithubUser(config *server.ServerConfig) {
+	config.GithubUser = strings.TrimPrefix(config.GithubUser, "@")
 }

--- a/server/command_handler.go
+++ b/server/command_handler.go
@@ -21,7 +21,7 @@ type CommandResponse struct {
 	Error          error
 	Failure        string
 	ProjectResults []ProjectResult
-	Command        CommandType
+	Command        CommandName
 }
 
 type ProjectResult struct {
@@ -42,16 +42,16 @@ func (p ProjectResult) Status() Status {
 	return Success
 }
 
-type CommandType int
+type CommandName int
 
 const (
-	Apply CommandType = iota
+	Apply CommandName = iota
 	Plan
 	Help
 	// Adding more? Don't forget to update String() below
 )
 
-func (c CommandType) String() string {
+func (c CommandName) String() string {
 	switch c {
 	case Apply:
 		return "apply"
@@ -64,9 +64,9 @@ func (c CommandType) String() string {
 }
 
 type Command struct {
-	verbose     bool
-	environment string
-	commandType CommandType
+	Verbose     bool
+	Environment string
+	Name        CommandName
 }
 
 func (c *CommandHandler) ExecuteCommand(ctx *CommandContext) {
@@ -95,7 +95,7 @@ func (c *CommandHandler) ExecuteCommand(ctx *CommandContext) {
 		return
 	}
 
-	switch ctx.Command.commandType {
+	switch ctx.Command.Name {
 	case Plan:
 		c.planExecutor.execute(ctx)
 	case Apply:

--- a/server/event_parser_test.go
+++ b/server/event_parser_test.go
@@ -1,0 +1,93 @@
+package server_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-github/github"
+	"github.com/hootsuite/atlantis/server"
+	. "github.com/hootsuite/atlantis/testing_util"
+)
+
+func TestDetermineCommandInvalid(t *testing.T) {
+	t.Log("given a comment that does not match the regex should return an error")
+	e := server.EventParser{"user"}
+	comments := []string{
+		// just the executable, no command
+		"run",
+		"atlantis",
+		"@user",
+		// invalid command
+		"run slkjd",
+		"atlantis slkjd",
+		"@user slkjd",
+		"atlantis plans",
+		// whitespace
+		"  atlantis plan",
+		// misc
+		"related comment mentioning atlantis",
+	}
+	for _, c := range comments {
+		_, e := e.DetermineCommand(buildComment(c))
+		Assert(t, e != nil, "expected error for comment: "+c)
+	}
+}
+
+func TestDetermineCommandHelp(t *testing.T) {
+	t.Log("given a help comment, should match")
+	e := server.EventParser{"user"}
+	comments := []string{
+		"run help",
+		"atlantis help",
+		"@user help",
+		"atlantis help --verbose",
+	}
+	for _, c := range comments {
+		command, e := e.DetermineCommand(buildComment(c))
+		Ok(t, e)
+		Equals(t, server.Help, command.Name)
+	}
+}
+
+func TestDetermineCommandPermutations(t *testing.T) {
+	e := server.EventParser{"user"}
+
+	execNames := []string{"run", "atlantis", "@user"}
+	commandNames := []server.CommandName{server.Plan, server.Apply}
+	envs := []string{"", "default", "env", "env-dash", "env_underscore", "camelEnv"}
+	verboses := []bool{true, false}
+
+	// test all permutations
+	for _, exec := range execNames {
+		for _, name := range commandNames {
+			for _, env := range envs {
+				for _, v := range verboses {
+					vFlag := ""
+					if v == true {
+						vFlag = "--verbose"
+					}
+
+					comment := fmt.Sprintf("%s %s %s %s", exec, name.String(), env, vFlag)
+					t.Log("testing comment: " + comment)
+					c, err := e.DetermineCommand(buildComment(comment))
+					Ok(t, err)
+					Equals(t, name, c.Name)
+					if env == "" {
+						Equals(t, "default", c.Environment)
+					} else {
+						Equals(t, env, c.Environment)
+					}
+					Equals(t, v, c.Verbose)
+				}
+			}
+		}
+	}
+}
+
+func buildComment(c string) *github.IssueCommentEvent {
+	return &github.IssueCommentEvent{
+		Comment: &github.IssueComment{
+			Body: github.String(c),
+		},
+	}
+}

--- a/server/github_status.go
+++ b/server/github_status.go
@@ -50,7 +50,7 @@ func (g *GithubStatus) UpdatePathResult(ctx *CommandContext, pathResults []Proje
 		statuses = append(statuses, p.Status())
 	}
 	worst := g.worstStatus(statuses)
-	return g.Update(ctx.BaseRepo, ctx.Pull, worst, ctx.Command.commandType.String())
+	return g.Update(ctx.BaseRepo, ctx.Pull, worst, ctx.Command.Name.String())
 }
 
 func (g *GithubStatus) worstStatus(ss []Status) Status {

--- a/server/server.go
+++ b/server/server.go
@@ -153,7 +153,9 @@ func NewServer(config ServerConfig) (*Server, error) {
 		workspace: workspace,
 	}
 	logger := logging.NewSimpleLogger("server", log.New(os.Stderr, "", log.LstdFlags), false, logging.ToLogLevel(config.LogLevel))
-	eventParser := &EventParser{}
+	eventParser := &EventParser{
+		GithubUser: config.GithubUser,
+	}
 	commandHandler := &CommandHandler{
 		applyExecutor: applyExecutor,
 		planExecutor:  planExecutor,

--- a/server/workspace.go
+++ b/server/workspace.go
@@ -66,5 +66,5 @@ func (w *Workspace) repoPullDir(repo models.Repo, pull models.PullRequest) strin
 }
 
 func (w *Workspace) cloneDir(ctx *CommandContext) string {
-	return filepath.Join(w.repoPullDir(ctx.BaseRepo, ctx.Pull), ctx.Command.environment)
+	return filepath.Join(w.repoPullDir(ctx.BaseRepo, ctx.Pull), ctx.Command.Environment)
 }


### PR DESCRIPTION
- now can call atlantis with @apiUser as well at simple atlantis string
- sanitize being called with `--gh-user @name` so we just use `name` and not `@name`
- make fields of `Command` exported so we can test it
- write test for the comment parsing

Fixes #2