### PR TITLE
Assume role refactor

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -33,11 +33,11 @@ const (
 var stringFlags = []stringFlag{
 	{
 		name:        atlantisURLFlag,
-		description: "Url that Atlantis can be reached at. Defaults to http://$(hostname):$port where $port is the port flag.",
+		description: "Url that Atlantis can be reached at. Defaults to http://$(hostname):$port where $port comes from the port flag.",
 	},
 	{
 		name:        awsAssumeRoleFlag,
-		description: "The Amazon Resource Name (`arn`) to assume when running Terraform commands. If not specified, will use AWS credentials via environment variables, or credentials files.",
+		description: "ARN of the role to assume when running Terraform against AWS. If not using assume role, no need to set.",
 	},
 	{
 		name:        awsRegionFlag,
@@ -55,18 +55,17 @@ var stringFlags = []stringFlag{
 	},
 	{
 		name:        ghHostnameFlag,
-		description: "Hostname of Github installation.",
+		description: "Hostname of your Github Enterprise installation. If using github.com, no need to set.",
 		value:       "github.com",
 	},
 	{
 		name:        ghPasswordFlag,
-		description: "GitHub password of API user. Can also be specified via the ATLANTIS_GH_PASSWORD environment variable.",
+		description: "[REQUIRED] GitHub password of API user. Can also be specified via the ATLANTIS_GH_PASSWORD environment variable.",
 		env:         "ATLANTIS_GH_PASSWORD",
 	},
 	{
 		name:        ghUserFlag,
-		description: "GitHub username of API user. Can also be specified via the ATLANTIS_GH_USER environment variable.",
-		env:         "ATLANTIS_GH_USER",
+		description: "[REQUIRED] GitHub username of API user.",
 	},
 	{
 		name:        logLevelFlag,

--- a/server/plan_executor.go
+++ b/server/plan_executor.go
@@ -148,9 +148,7 @@ func (p *PlanExecutor) plan(ctx *CommandContext, repoDir string, project models.
 		}
 	}
 
-	// set pull request creator as the session name
-	p.awsConfig.SessionName = ctx.Pull.Author
-	awsSession, err := p.awsConfig.CreateSession()
+	awsSession, err := p.awsConfig.CreateSession(ctx.User.Username)
 	if err != nil {
 		ctx.Log.Err(err.Error())
 		return ProjectResult{Error: err}

--- a/server/server.go
+++ b/server/server.go
@@ -183,7 +183,7 @@ func (s *Server) Start() error {
 		StackSize:  1024 * 8,
 	}, NewRequestLogger(s.logger))
 	n.UseHandler(s.router)
-	s.logger.Info("Atlantis started - listening on port %v", s.port)
+	s.logger.Warn("Atlantis started - listening on port %v", s.port)
 	return cli.NewExitError(http.ListenAndServe(fmt.Sprintf(":%d", s.port), n), 1)
 }
 


### PR DESCRIPTION
We had a bug where we were mutating the state inside the AWS struct on each run. Now we're passing in that state.

* remove environment variable for github user since it's not sensitive
* show error when users add a non supported flag (previously it would just print help text but not say the error)
* use Warn for log starting the server so if they're using the default log level (warn) they still see the log about the server starting