### PR TITLE
Adding github webhook secret key option. Fixes #34

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -17,17 +17,18 @@ import (
 // 2. Add a new field to server.ServerConfig and set the mapstructure tag equal to the flag name
 // 3. Add your flag's description etc. to the stringFlags, intFlags, or boolFlags slices
 const (
-	atlantisURLFlag     = "atlantis-url"
-	awsAssumeRoleFlag   = "aws-assume-role-arn"
-	awsRegionFlag       = "aws-region"
-	configFlag          = "config"
-	dataDirFlag         = "data-dir"
-	ghHostnameFlag      = "gh-hostname"
-	ghTokenFlag         = "gh-token"
-	ghUserFlag          = "gh-user"
-	logLevelFlag        = "log-level"
-	portFlag            = "port"
-	requireApprovalFlag = "require-approval"
+	atlantisURLFlag      = "atlantis-url"
+	awsAssumeRoleFlag    = "aws-assume-role-arn"
+	awsRegionFlag        = "aws-region"
+	configFlag           = "config"
+	dataDirFlag          = "data-dir"
+	ghHostnameFlag       = "gh-hostname"
+	ghTokenFlag          = "gh-token"
+	ghUserFlag           = "gh-user"
+	logLevelFlag         = "log-level"
+	portFlag             = "port"
+	requireApprovalFlag  = "require-approval"
+	webhookSecretKeyFlag = "webhook-secret-key"
 )
 
 var stringFlags = []stringFlag{
@@ -71,6 +72,11 @@ var stringFlags = []stringFlag{
 		name:        logLevelFlag,
 		description: "Log level. Either debug, info, warn, or error.",
 		value:       "info",
+	},
+	{
+		name:        webhookSecretKeyFlag,
+		description: "Github webhook secret key. Can also be specified via the ATLANTIS_GH_WEBHOOK_SECRET_KEY environment variable.",
+		env:         "ATLANTIS_GH_WEBHOOK_SECRET_KEY",
 	},
 }
 var boolFlags = []boolFlag{

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -17,18 +17,18 @@ import (
 // 2. Add a new field to server.ServerConfig and set the mapstructure tag equal to the flag name
 // 3. Add your flag's description etc. to the stringFlags, intFlags, or boolFlags slices
 const (
-	atlantisURLFlag      = "atlantis-url"
-	awsAssumeRoleFlag    = "aws-assume-role-arn"
-	awsRegionFlag        = "aws-region"
-	configFlag           = "config"
-	dataDirFlag          = "data-dir"
-	ghHostnameFlag       = "gh-hostname"
-	ghTokenFlag          = "gh-token"
-	ghUserFlag           = "gh-user"
-	logLevelFlag         = "log-level"
-	portFlag             = "port"
-	requireApprovalFlag  = "require-approval"
-	webhookSecretKeyFlag = "webhook-secret-key"
+	atlantisURLFlag        = "atlantis-url"
+	awsAssumeRoleFlag      = "aws-assume-role-arn"
+	awsRegionFlag          = "aws-region"
+	configFlag             = "config"
+	dataDirFlag            = "data-dir"
+	ghHostnameFlag         = "gh-hostname"
+	ghTokenFlag            = "gh-token"
+	ghUserFlag             = "gh-user"
+	ghWebhookSecretKeyFlag = "gh-webhook-secret-key"
+	logLevelFlag           = "log-level"
+	portFlag               = "port"
+	requireApprovalFlag    = "require-approval"
 )
 
 var stringFlags = []stringFlag{
@@ -74,7 +74,7 @@ var stringFlags = []stringFlag{
 		value:       "info",
 	},
 	{
-		name:        webhookSecretKeyFlag,
+		name:        ghWebhookSecretKeyFlag,
 		description: "Github webhook secret key. Can also be specified via the ATLANTIS_GH_WEBHOOK_SECRET_KEY environment variable.",
 		env:         "ATLANTIS_GH_WEBHOOK_SECRET_KEY",
 	},

--- a/server/event_parser.go
+++ b/server/event_parser.go
@@ -11,8 +11,9 @@ import (
 )
 
 type EventParser struct {
-	GithubUser  string
-	GithubToken string
+	GithubUser             string
+	GithubToken            string
+	GithubWehbookSecretKey string
 }
 
 func (e *EventParser) DetermineCommand(comment *github.IssueCommentEvent) (*Command, error) {

--- a/server/event_parser_test.go
+++ b/server/event_parser_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestDetermineCommandInvalid(t *testing.T) {
 	t.Log("given a comment that does not match the regex should return an error")
-	e := server.EventParser{"user", "token"}
+	e := server.EventParser{"user", "token", "webhook-secret"}
 	comments := []string{
 		// just the executable, no command
 		"run",
@@ -35,7 +35,7 @@ func TestDetermineCommandInvalid(t *testing.T) {
 
 func TestDetermineCommandHelp(t *testing.T) {
 	t.Log("given a help comment, should match")
-	e := server.EventParser{"user", "token"}
+	e := server.EventParser{"user", "token", "webhook-secret"}
 	comments := []string{
 		"run help",
 		"atlantis help",
@@ -50,7 +50,7 @@ func TestDetermineCommandHelp(t *testing.T) {
 }
 
 func TestDetermineCommandPermutations(t *testing.T) {
-	e := server.EventParser{"user", "token"}
+	e := server.EventParser{"user", "token", "webhook-secret"}
 
 	execNames := []string{"run", "atlantis", "@user"}
 	commandNames := []server.CommandName{server.Plan, server.Apply}

--- a/server/server.go
+++ b/server/server.go
@@ -52,7 +52,7 @@ type ServerConfig struct {
 	GithubHostname         string `mapstructure:"gh-hostname"`
 	GithubToken            string `mapstructure:"gh-token"`
 	GithubUser             string `mapstructure:"gh-user"`
-	GithubWebhookSecretKey string `mapstructure:"webhook-secret-key"`
+	GithubWebhookSecretKey string `mapstructure:"gh-webhook-secret-key"`
 	LogLevel               string `mapstructure:"log-level"`
 	Port                   int    `mapstructure:"port"`
 	RequireApproval        bool   `mapstructure:"require-approval"`


### PR DESCRIPTION
* Adding new CLI flag `gh-webhook-secret-key` to supply Github webhook secret key to verify payloads.

TODO:
- [ ] Add a docs about the flag in README.md