### PR TITLE
New parsing of comments. Accept all flags. Fixes #129

### DIFF
--- a/server/apply_executor.go
+++ b/server/apply_executor.go
@@ -145,7 +145,7 @@ func (a *ApplyExecutor) apply(ctx *CommandContext, repoDir string, plan models.P
 		}
 	}
 
-	tfApplyCmd := append([]string{"apply", "-no-color", plan.LocalPath}, applyExtraArgs...)
+	tfApplyCmd := append(append([]string{"apply", "-no-color", plan.LocalPath}, applyExtraArgs...), ctx.Command.Flags...)
 	output, err := a.terraform.RunCommandWithVersion(ctx.Log, absolutePath, tfApplyCmd, terraformVersion)
 	if err != nil {
 		return ProjectResult{Error: fmt.Errorf("%s\n%s", err.Error(), output)}

--- a/server/command_handler.go
+++ b/server/command_handler.go
@@ -64,9 +64,10 @@ func (c CommandName) String() string {
 }
 
 type Command struct {
-	Verbose     bool
-	Environment string
 	Name        CommandName
+	Environment string
+	Verbose     bool
+	Flags       []string
 }
 
 func (c *CommandHandler) ExecuteCommand(ctx *CommandContext) {

--- a/server/event_parser_test.go
+++ b/server/event_parser_test.go
@@ -1,12 +1,12 @@
 package server_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/go-github/github"
 	"github.com/hootsuite/atlantis/server"
 	. "github.com/hootsuite/atlantis/testing_util"
+	"strings"
 )
 
 func TestDetermineCommandInvalid(t *testing.T) {
@@ -22,8 +22,6 @@ func TestDetermineCommandInvalid(t *testing.T) {
 		"atlantis slkjd",
 		"@user slkjd",
 		"atlantis plans",
-		// whitespace
-		"  atlantis plan",
 		// misc
 		"related comment mentioning atlantis",
 	}
@@ -55,29 +53,50 @@ func TestDetermineCommandPermutations(t *testing.T) {
 	execNames := []string{"run", "atlantis", "@user"}
 	commandNames := []server.CommandName{server.Plan, server.Apply}
 	envs := []string{"", "default", "env", "env-dash", "env_underscore", "camelEnv"}
-	verboses := []bool{true, false}
+	flagCases := [][]string{
+		[]string{},
+		[]string{"--verbose"},
+		[]string{"-key=value"},
+		[]string{"-key", "value"},
+		[]string{"-key1=value1", "-key2=value2"},
+		[]string{"-key1=value1", "-key2", "value2"},
+		[]string{"-key1", "value1", "-key2=value2"},
+		[]string{"--verbose", "key2=value2"},
+		[]string{"-key1=value1", "--verbose"},
+	}
 
 	// test all permutations
 	for _, exec := range execNames {
 		for _, name := range commandNames {
 			for _, env := range envs {
-				for _, v := range verboses {
-					vFlag := ""
-					if v == true {
-						vFlag = "--verbose"
-					}
+				for _, flags := range flagCases {
+					// If github comments end in a newline they get \r\n appended.
+					// Ensure that we parse commands properly either way.
+					for _, lineEnding := range []string{"", "\r\n"} {
+						comment := strings.Join(append([]string{exec, name.String(), env}, flags...), " ") + lineEnding
+						t.Log("testing comment: " + comment)
+						c, err := e.DetermineCommand(buildComment(comment))
+						Ok(t, err)
+						Equals(t, name, c.Name)
+						if env == "" {
+							Equals(t, "default", c.Environment)
+						} else {
+							Equals(t, env, c.Environment)
+						}
+						Equals(t, stringInSlice("--verbose", flags), c.Verbose)
 
-					comment := fmt.Sprintf("%s %s %s %s", exec, name.String(), env, vFlag)
-					t.Log("testing comment: " + comment)
-					c, err := e.DetermineCommand(buildComment(comment))
-					Ok(t, err)
-					Equals(t, name, c.Name)
-					if env == "" {
-						Equals(t, "default", c.Environment)
-					} else {
-						Equals(t, env, c.Environment)
+						// ensure --verbose never shows up in flags
+						for _, f := range c.Flags {
+							Assert(t, f != "--verbose", "Should not pass on the --verbose flag: %v", flags)
+						}
+
+						// check all flags are present
+						for _, f := range flags {
+							if f != "--verbose" {
+								Contains(t, f, c.Flags)
+							}
+						}
 					}
-					Equals(t, v, c.Verbose)
 				}
 			}
 		}
@@ -91,3 +110,13 @@ func buildComment(c string) *github.IssueCommentEvent {
 		},
 	}
 }
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+

--- a/server/plan_executor.go
+++ b/server/plan_executor.go
@@ -148,7 +148,8 @@ func (p *PlanExecutor) plan(ctx *CommandContext, repoDir string, project models.
 
 	// Run terraform plan
 	planFile := filepath.Join(repoDir, project.Path, fmt.Sprintf("%s.tfplan", tfEnv))
-	tfPlanCmd := append([]string{"plan", "-refresh", "-no-color", "-out", planFile, "-var", fmt.Sprintf("%s=%s", atlantisUserTFVar, ctx.User.Username)}, planExtraArgs...)
+	userVar := fmt.Sprintf("%s=%s", atlantisUserTFVar, ctx.User.Username)
+	tfPlanCmd := append(append([]string{"plan", "-refresh", "-no-color", "-out", planFile, "-var", userVar}, planExtraArgs...), ctx.Command.Flags...)
 
 	// check if env/{environment}.tfvars exist
 	tfEnvFileName := filepath.Join("env", tfEnv+".tfvars")

--- a/server/server.go
+++ b/server/server.go
@@ -384,7 +384,6 @@ func (s *Server) handleCommentEvent(w http.ResponseWriter, event *gh.IssueCommen
 		return
 	}
 
-	// determine if the comment matches a plan or apply command
 	ctx := &CommandContext{}
 	command, err := s.eventParser.DetermineCommand(event)
 	if err != nil {

--- a/testing_util/testing_util.go
+++ b/testing_util/testing_util.go
@@ -38,9 +38,9 @@ func Equals(tb testing.TB, exp, act interface{}) {
 }
 
 // Contains fails the test if the slice doesn't contain the expected element
-func Contains(tb testing.TB, exp interface{}, slice []interface{}) {
+func Contains(tb testing.TB, exp interface{}, slice []string) {
 	for _, v := range slice {
-		if reflect.DeepEqual(v, exp) {
+		if v == exp {
 			return
 		}
 	}


### PR DESCRIPTION
- Pass through additional arguments to `plan` and `apply` directly through to terraform
- remove regex for command parsing to enable the more complicated parsing now required

Fixes #129 
Fixes #133 