### PR TITLE
Fixed key name documentation on extra_arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ post_apply:
   commands:
   - "curl http://example.com"
 extra_arguments:
-  - command: plan
+  - command_name: plan
     arguments:
     - "-tfvars=myvars.tfvars"
 ```


### PR DESCRIPTION
Updates the Readme with `command_name` key in the example `atlantis.yaml` configuration.

[Reference](https://github.com/hootsuite/atlantis/blob/master/server/project_config.go#L53)