### PR TITLE
Add coverage script that supports multiple packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ atlantis.db
 output
 website/src/public
 .DS_Store
+.cover

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,7 @@ test: ## Run tests, coverage reports, and clean (coverage taints the compiled co
 	go test $(PKG)
 
 test-coverage:
-	go test $(PKG) -coverprofile=c.out
-	go tool cover -html=c.out -o coverage.html
+	./scripts/coverage.sh
 
 dist: ## Package up everything in static/ using go-bindata-assetfs so it can be served by a single binary
 	go-bindata-assetfs -pkg server static/... && mv bindata_assetfs.go server

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# From https://github.com/mlafeldt/chef-runner/blob/v0.7.0/script/coverage
+# Generate test coverage statistics for Go packages.
+#
+# Works around the fact that `go test -coverprofile` currently does not work
+# with multiple packages, see https://code.google.com/p/go/issues/detail?id=6909
+#
+# Usage: script/coverage [--html]
+#
+#     --html      Additionally create HTML report and open it in browser
+#
+
+set -e
+
+workdir=.cover
+profile="$workdir/cover.out"
+mode=count
+
+generate_cover_data() {
+    rm -rf "$workdir"
+    mkdir "$workdir"
+
+    pkgs=$(go list ./... | grep -v e2e | grep -v vendor | grep -v static)
+    for pkg in $pkgs; do
+        f="$workdir/$(echo $pkg | tr / -).cover"
+        go test -covermode="$mode" -coverprofile="$f" "$pkg"
+    done
+
+    echo "mode: $mode" >"$profile"
+    grep -h -v "^mode:" "$workdir"/*.cover >>"$profile"
+}
+
+show_cover_report() {
+    go tool cover -${1}="$profile"
+}
+
+generate_cover_data $(go list ./...)
+show_cover_report func
+case "$1" in
+"")
+    ;;
+--html)
+    show_cover_report html ;;
+*)
+    echo >&2 "error: invalid option: $1"; exit 1 ;;
+esac


### PR DESCRIPTION
go test -cover doesn't work out of the box with multiple packages