### PR TITLE
Update to latest version of go-github

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -35,7 +35,7 @@
   branch = "master"
   name = "github.com/google/go-github"
   packages = ["github"]
-  revision = "12126fbfe000a09047ebdeb2b5160be3af88ab9e"
+  revision = "c004bf0c02fcab9d87a7f2e2f002fd008bf0784c"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/google/go-github/.travis.yml
+++ b/vendor/github.com/google/go-github/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: go
 go:
+  - 1.9.x
   - 1.8.x
   - 1.7.x
   - master

--- a/vendor/github.com/google/go-github/example/appengine/app.go
+++ b/vendor/github.com/google/go-github/example/appengine/app.go
@@ -3,7 +3,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// The demo app shows how to use the github package on Google App Engine.
+// Package demo provides an app that shows how to use the github package on
+// Google App Engine.
 package demo
 
 import (

--- a/vendor/github.com/google/go-github/github/github-accessors.go
+++ b/vendor/github.com/google/go-github/github/github-accessors.go
@@ -2100,12 +2100,28 @@ func (i *Issue) GetComments() int {
 	return *i.Comments
 }
 
+// GetCommentsURL returns the CommentsURL field if it's non-nil, zero value otherwise.
+func (i *Issue) GetCommentsURL() string {
+	if i == nil || i.CommentsURL == nil {
+		return ""
+	}
+	return *i.CommentsURL
+}
+
 // GetCreatedAt returns the CreatedAt field if it's non-nil, zero value otherwise.
 func (i *Issue) GetCreatedAt() time.Time {
 	if i == nil || i.CreatedAt == nil {
 		return time.Time{}
 	}
 	return *i.CreatedAt
+}
+
+// GetEventsURL returns the EventsURL field if it's non-nil, zero value otherwise.
+func (i *Issue) GetEventsURL() string {
+	if i == nil || i.EventsURL == nil {
+		return ""
+	}
+	return *i.EventsURL
 }
 
 // GetHTMLURL returns the HTMLURL field if it's non-nil, zero value otherwise.
@@ -2124,6 +2140,14 @@ func (i *Issue) GetID() int {
 	return *i.ID
 }
 
+// GetLabelsURL returns the LabelsURL field if it's non-nil, zero value otherwise.
+func (i *Issue) GetLabelsURL() string {
+	if i == nil || i.LabelsURL == nil {
+		return ""
+	}
+	return *i.LabelsURL
+}
+
 // GetLocked returns the Locked field if it's non-nil, zero value otherwise.
 func (i *Issue) GetLocked() bool {
 	if i == nil || i.Locked == nil {
@@ -2138,6 +2162,14 @@ func (i *Issue) GetNumber() int {
 		return 0
 	}
 	return *i.Number
+}
+
+// GetRepositoryURL returns the RepositoryURL field if it's non-nil, zero value otherwise.
+func (i *Issue) GetRepositoryURL() string {
+	if i == nil || i.RepositoryURL == nil {
+		return ""
+	}
+	return *i.RepositoryURL
 }
 
 // GetState returns the State field if it's non-nil, zero value otherwise.

--- a/vendor/github.com/google/go-github/github/github.go
+++ b/vendor/github.com/google/go-github/github/github.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	libraryVersion = "11"
+	libraryVersion = "12"
 	defaultBaseURL = "https://api.github.com/"
 	uploadBaseURL  = "https://uploads.github.com/"
 	userAgent      = "go-github/" + libraryVersion

--- a/vendor/github.com/google/go-github/github/issues.go
+++ b/vendor/github.com/google/go-github/github/issues.go
@@ -23,6 +23,7 @@ type IssuesService service
 // but not every issue is a pull request. Some endpoints, events, and webhooks
 // may also return pull requests via this struct. If PullRequestLinks is nil,
 // this is an issue, and if PullRequestLinks is not nil, this is a pull request.
+// The IsPullRequest helper method can be used to check that.
 type Issue struct {
 	ID               *int              `json:"id,omitempty"`
 	Number           *int              `json:"number,omitempty"`
@@ -40,6 +41,10 @@ type Issue struct {
 	ClosedBy         *User             `json:"closed_by,omitempty"`
 	URL              *string           `json:"url,omitempty"`
 	HTMLURL          *string           `json:"html_url,omitempty"`
+	CommentsURL      *string           `json:"comments_url,omitempty"`
+	EventsURL        *string           `json:"events_url,omitempty"`
+	LabelsURL        *string           `json:"labels_url,omitempty"`
+	RepositoryURL    *string           `json:"repository_url,omitempty"`
 	Milestone        *Milestone        `json:"milestone,omitempty"`
 	PullRequestLinks *PullRequestLinks `json:"pull_request,omitempty"`
 	Repository       *Repository       `json:"repository,omitempty"`
@@ -53,6 +58,13 @@ type Issue struct {
 
 func (i Issue) String() string {
 	return Stringify(i)
+}
+
+// IsPullRequest reports whether the issue is also a pull request. It uses the
+// method recommended by GitHub's API documentation, which is to check whether
+// PullRequestLinks is non-nil.
+func (i Issue) IsPullRequest() bool {
+	return i.PullRequestLinks != nil
 }
 
 // IssueRequest represents a request to create/edit an issue.
@@ -97,7 +109,7 @@ type IssueListOptions struct {
 }
 
 // PullRequestLinks object is added to the Issue object when it's an issue included
-// in the IssueCommentEvent webhook payload, if the webhooks is fired by a comment on a PR
+// in the IssueCommentEvent webhook payload, if the webhook is fired by a comment on a PR.
 type PullRequestLinks struct {
 	URL      *string `json:"url,omitempty"`
 	HTMLURL  *string `json:"html_url,omitempty"`

--- a/vendor/github.com/google/go-github/github/issues_test.go
+++ b/vendor/github.com/google/go-github/github/issues_test.go
@@ -275,3 +275,14 @@ func TestIssuesService_Unlock(t *testing.T) {
 		t.Errorf("Issues.Unlock returned error: %v", err)
 	}
 }
+
+func TestIsPullRequest(t *testing.T) {
+	i := new(Issue)
+	if i.IsPullRequest() == true {
+		t.Errorf("expected i.IsPullRequest (%v) to return false, got true", i)
+	}
+	i.PullRequestLinks = &PullRequestLinks{URL: String("http://example.com")}
+	if i.IsPullRequest() == false {
+		t.Errorf("expected i.IsPullRequest (%v) to return true, got false", i)
+	}
+}

--- a/vendor/github.com/google/go-github/github/orgs_members.go
+++ b/vendor/github.com/google/go-github/github/orgs_members.go
@@ -278,7 +278,7 @@ func (s *OrganizationsService) RemoveOrgMembership(ctx context.Context, user, or
 // ListPendingOrgInvitations returns a list of pending invitations.
 //
 // GitHub API docs: https://developer.github.com/v3/orgs/members/#list-pending-organization-invitations
-func (s *OrganizationsService) ListPendingOrgInvitations(ctx context.Context, org int, opt *ListOptions) ([]*Invitation, *Response, error) {
+func (s *OrganizationsService) ListPendingOrgInvitations(ctx context.Context, org string, opt *ListOptions) ([]*Invitation, *Response, error) {
 	u := fmt.Sprintf("orgs/%v/invitations", org)
 	u, err := addOptions(u, opt)
 	if err != nil {

--- a/vendor/github.com/google/go-github/github/orgs_members_test.go
+++ b/vendor/github.com/google/go-github/github/orgs_members_test.go
@@ -360,7 +360,7 @@ func TestOrganizationsService_ListPendingOrgInvitations(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/orgs/1/invitations", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/o/invitations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{"page": "1"})
 		fmt.Fprint(w, `[
@@ -394,7 +394,7 @@ func TestOrganizationsService_ListPendingOrgInvitations(t *testing.T) {
 	})
 
 	opt := &ListOptions{Page: 1}
-	invitations, _, err := client.Organizations.ListPendingOrgInvitations(context.Background(), 1, opt)
+	invitations, _, err := client.Organizations.ListPendingOrgInvitations(context.Background(), "o", opt)
 	if err != nil {
 		t.Errorf("Organizations.ListPendingOrgInvitations returned error: %v", err)
 	}

--- a/vendor/github.com/google/go-github/github/repos.go
+++ b/vendor/github.com/google/go-github/github/repos.go
@@ -558,7 +558,7 @@ type RequiredStatusChecks struct {
 
 // PullRequestReviewsEnforcement represents the pull request reviews enforcement of a protected branch.
 type PullRequestReviewsEnforcement struct {
-	// Specifies which users and teams can dismiss pull requets reviews.
+	// Specifies which users and teams can dismiss pull request reviews.
 	DismissalRestrictions DismissalRestrictions `json:"dismissal_restrictions"`
 	// Specifies if approved reviews are dismissed automatically, when a new commit is pushed.
 	DismissStaleReviews bool `json:"dismiss_stale_reviews"`
@@ -568,7 +568,7 @@ type PullRequestReviewsEnforcement struct {
 // enforcement of a protected branch. It is separate from PullRequestReviewsEnforcement above
 // because the request structure is different from the response structure.
 type PullRequestReviewsEnforcementRequest struct {
-	// Specifies which users and teams should be allowed to dismiss pull requets reviews. Can be nil to disable the restrictions.
+	// Specifies which users and teams should be allowed to dismiss pull request reviews. Can be nil to disable the restrictions.
 	DismissalRestrictionsRequest *DismissalRestrictionsRequest `json:"dismissal_restrictions"`
 	// Specifies if approved reviews can be dismissed automatically, when a new commit is pushed. (Required)
 	DismissStaleReviews bool `json:"dismiss_stale_reviews"`
@@ -601,9 +601,9 @@ func (req PullRequestReviewsEnforcementRequest) MarshalJSON() ([]byte, error) {
 // enforcement of a protected branch. It is separate from PullRequestReviewsEnforcementRequest above
 // because the patch request does not require all fields to be initialized.
 type PullRequestReviewsEnforcementUpdate struct {
-	// Specifies which users and teams can dismiss pull requets reviews. Can be ommitted.
+	// Specifies which users and teams can dismiss pull request reviews. Can be omitted.
 	DismissalRestrictionsRequest *DismissalRestrictionsRequest `json:"dismissal_restrictions,omitempty"`
-	// Specifies if approved reviews can be dismissed automatically, when a new commit is pushed. Can be ommited.
+	// Specifies if approved reviews can be dismissed automatically, when a new commit is pushed. Can be omitted.
 	DismissStaleReviews *bool `json:"dismiss_stale_reviews,omitempty"`
 }
 

--- a/vendor/github.com/google/go-github/github/timestamp_test.go
+++ b/vendor/github.com/google/go-github/github/timestamp_test.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	emptyTimeStr         = `"0001-01-01T00:00:00Z"`
-	referenceTimeStr     = `"2006-01-02T15:04:05Z"`
-	referenceUnixTimeStr = `1136214245`
+	emptyTimeStr               = `"0001-01-01T00:00:00Z"`
+	referenceTimeStr           = `"2006-01-02T15:04:05Z"`
+	referenceTimeStrFractional = `"2006-01-02T15:04:05.000Z"` // This format was returned by the Projects API before October 1, 2017.
+	referenceUnixTimeStr       = `1136214245`
 )
 
 var (
@@ -57,7 +58,8 @@ func TestTimestamp_Unmarshal(t *testing.T) {
 		equal   bool
 	}{
 		{"Reference", referenceTimeStr, Timestamp{referenceTime}, false, true},
-		{"ReferenceUnix", `1136214245`, Timestamp{referenceTime}, false, true},
+		{"ReferenceUnix", referenceUnixTimeStr, Timestamp{referenceTime}, false, true},
+		{"ReferenceFractional", referenceTimeStrFractional, Timestamp{referenceTime}, false, true},
 		{"Empty", emptyTimeStr, Timestamp{}, false, true},
 		{"UnixStart", `0`, Timestamp{unixOrigin}, false, true},
 		{"Mismatch", referenceTimeStr, Timestamp{}, false, false},


### PR DESCRIPTION
Now that https://github.com/google/go-github/pull/693 is merged, we can use the `go-github` code to validate webhook requests that use secrets.

We still need to parse the request ourselves if they're not using secrets since the `go-github` library doesn't have that capability.