### PR TITLE
use 'terraform workspace' for terraform versions >= 0.10.x. Fixes #142

### DIFF
--- a/server/events/project_pre_execute.go
+++ b/server/events/project_pre_execute.go
@@ -65,7 +65,7 @@ func (p *ProjectPreExecute) Execute(ctx *CommandContext, repoDir string, project
 				return PreExecuteResult{ProjectResult: ProjectResult{Error: errors.Wrapf(err, "running %s commands", "pre_init")}}
 			}
 		}
-		_, err := p.Terraform.RunInitAndEnv(ctx.Log, absolutePath, tfEnv, config.GetExtraArguments("init"), terraformVersion)
+		_, err := p.Terraform.RunInitAndWorkspace(ctx.Log, absolutePath, tfEnv, config.GetExtraArguments("init"), terraformVersion)
 		if err != nil {
 			return PreExecuteResult{ProjectResult: ProjectResult{Error: err}}
 		}

--- a/server/events/project_pre_execute_test.go
+++ b/server/events/project_pre_execute_test.go
@@ -90,7 +90,7 @@ func TestExecute_InitErr(t *testing.T) {
 	When(p.ConfigReader.Read("")).ThenReturn(events.ProjectConfig{}, nil)
 	tfVersion, _ := version.NewVersion("0.9.0")
 	When(tm.Version()).ThenReturn(tfVersion)
-	When(tm.RunInitAndEnv(ctx.Log, "", "", nil, tfVersion)).ThenReturn(nil, errors.New("err"))
+	When(tm.RunInitAndWorkspace(ctx.Log, "", "", nil, tfVersion)).ThenReturn(nil, errors.New("err"))
 
 	res := p.Execute(&ctx, "", project)
 	Equals(t, "err", res.ProjectResult.Error.Error())
@@ -142,7 +142,7 @@ func TestExecute_PreCommandErr(t *testing.T) {
 	}, nil)
 	tfVersion, _ := version.NewVersion("0.9")
 	When(tm.Version()).ThenReturn(tfVersion)
-	When(tm.RunInitAndEnv(ctx.Log, "", "", nil, tfVersion)).ThenReturn(nil, nil)
+	When(tm.RunInitAndWorkspace(ctx.Log, "", "", nil, tfVersion)).ThenReturn(nil, nil)
 	When(r.Execute(ctx.Log, []string{"command"}, "", "", tfVersion, "pre_plan")).ThenReturn("", errors.New("err"))
 
 	res := p.Execute(&ctx, "", project)
@@ -163,7 +163,7 @@ func TestExecute_SuccessTF9(t *testing.T) {
 	When(p.ConfigReader.Read("")).ThenReturn(config, nil)
 	tfVersion, _ := version.NewVersion("0.9")
 	When(tm.Version()).ThenReturn(tfVersion)
-	When(tm.RunInitAndEnv(ctx.Log, "", "", nil, tfVersion)).ThenReturn(nil, nil)
+	When(tm.RunInitAndWorkspace(ctx.Log, "", "", nil, tfVersion)).ThenReturn(nil, nil)
 
 	res := p.Execute(&ctx, "", project)
 	Equals(t, events.PreExecuteResult{
@@ -171,7 +171,7 @@ func TestExecute_SuccessTF9(t *testing.T) {
 		TerraformVersion: tfVersion,
 		LockResponse:     lockResponse,
 	}, res)
-	tm.VerifyWasCalledOnce().RunInitAndEnv(ctx.Log, "", "", nil, tfVersion)
+	tm.VerifyWasCalledOnce().RunInitAndWorkspace(ctx.Log, "", "", nil, tfVersion)
 	r.VerifyWasCalledOnce().Execute(ctx.Log, []string{"pre-init"}, "", "", tfVersion, "pre_init")
 }
 

--- a/server/events/terraform/mocks/mock_runner.go
+++ b/server/events/terraform/mocks/mock_runner.go
@@ -4,10 +4,11 @@
 package mocks
 
 import (
+	"reflect"
+
 	go_version "github.com/hashicorp/go-version"
 	logging "github.com/hootsuite/atlantis/server/logging"
 	pegomock "github.com/petergtz/pegomock"
-	"reflect"
 )
 
 type MockRunner struct {
@@ -46,9 +47,9 @@ func (mock *MockRunner) RunCommandWithVersion(log *logging.SimpleLogger, path st
 	return ret0, ret1
 }
 
-func (mock *MockRunner) RunInitAndEnv(log *logging.SimpleLogger, path string, env string, extraInitArgs []string, version *go_version.Version) ([]string, error) {
+func (mock *MockRunner) RunInitAndWorkspace(log *logging.SimpleLogger, path string, env string, extraInitArgs []string, version *go_version.Version) ([]string, error) {
 	params := []pegomock.Param{log, path, env, extraInitArgs, version}
-	result := pegomock.GetGenericMockFrom(mock).Invoke("RunInitAndEnv", params, []reflect.Type{reflect.TypeOf((*[]string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
+	result := pegomock.GetGenericMockFrom(mock).Invoke("RunInitAndWorkspace", params, []reflect.Type{reflect.TypeOf((*[]string)(nil)).Elem(), reflect.TypeOf((*error)(nil)).Elem()})
 	var ret0 []string
 	var ret1 error
 	if len(result) != 0 {
@@ -140,23 +141,23 @@ func (c *Runner_RunCommandWithVersion_OngoingVerification) GetAllCapturedArgumen
 	return
 }
 
-func (verifier *VerifierRunner) RunInitAndEnv(log *logging.SimpleLogger, path string, env string, extraInitArgs []string, version *go_version.Version) *Runner_RunInitAndEnv_OngoingVerification {
+func (verifier *VerifierRunner) RunInitAndWorkspace(log *logging.SimpleLogger, path string, env string, extraInitArgs []string, version *go_version.Version) *Runner_RunInitAndWorkspace_OngoingVerification {
 	params := []pegomock.Param{log, path, env, extraInitArgs, version}
-	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "RunInitAndEnv", params)
-	return &Runner_RunInitAndEnv_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
+	methodInvocations := pegomock.GetGenericMockFrom(verifier.mock).Verify(verifier.inOrderContext, verifier.invocationCountMatcher, "RunInitAndWorkspace", params)
+	return &Runner_RunInitAndWorkspace_OngoingVerification{mock: verifier.mock, methodInvocations: methodInvocations}
 }
 
-type Runner_RunInitAndEnv_OngoingVerification struct {
+type Runner_RunInitAndWorkspace_OngoingVerification struct {
 	mock              *MockRunner
 	methodInvocations []pegomock.MethodInvocation
 }
 
-func (c *Runner_RunInitAndEnv_OngoingVerification) GetCapturedArguments() (*logging.SimpleLogger, string, string, []string, *go_version.Version) {
+func (c *Runner_RunInitAndWorkspace_OngoingVerification) GetCapturedArguments() (*logging.SimpleLogger, string, string, []string, *go_version.Version) {
 	log, path, env, extraInitArgs, version := c.GetAllCapturedArguments()
 	return log[len(log)-1], path[len(path)-1], env[len(env)-1], extraInitArgs[len(extraInitArgs)-1], version[len(version)-1]
 }
 
-func (c *Runner_RunInitAndEnv_OngoingVerification) GetAllCapturedArguments() (_param0 []*logging.SimpleLogger, _param1 []string, _param2 []string, _param3 [][]string, _param4 []*go_version.Version) {
+func (c *Runner_RunInitAndWorkspace_OngoingVerification) GetAllCapturedArguments() (_param0 []*logging.SimpleLogger, _param1 []string, _param2 []string, _param3 [][]string, _param4 []*go_version.Version) {
 	params := pegomock.GetGenericMockFrom(c.mock).GetInvocationParams(c.methodInvocations)
 	if len(params) > 0 {
 		_param0 = make([]*logging.SimpleLogger, len(params[0]))

--- a/server/events/terraform/terraform_client.go
+++ b/server/events/terraform/terraform_client.go
@@ -102,7 +102,7 @@ func (c *Client) RunCommandWithVersion(log *logging.SimpleLogger, path string, a
 // 2. "terraform workspace or env select" - This selects the workspace or environment for the terraform project
 // [optional] 3. "terraform workspace or env new" - This creates a new workspace or environment for the terraform project
 // env is the environment supplied by the atlantis user that is used to
-// select or create a new workspace or environment for terraform
+// select or create a new workspace or environment for terraform.
 func (c *Client) RunInitAndWorkspace(log *logging.SimpleLogger, path string, env string, extraInitArgs []string, v *version.Version) ([]string, error) {
 	var outputs []string
 	// run terraform init
@@ -120,7 +120,6 @@ func (c *Client) RunInitAndWorkspace(log *logging.SimpleLogger, path string, env
 		workspaceCmdName = "env"
 	}
 
-	// Run 'terraform workspace/env select'
 	output, err = c.RunCommandWithVersion(log, path, []string{workspaceCmdName, "select", "-no-color", env}, v, env)
 	outputs = append(outputs, output)
 	if err != nil {

--- a/server/events/terraform/terraform_client.go
+++ b/server/events/terraform/terraform_client.go
@@ -18,7 +18,7 @@ import (
 type Runner interface {
 	Version() *version.Version
 	RunCommandWithVersion(log *logging.SimpleLogger, path string, args []string, v *version.Version, env string) (string, error)
-	RunInitAndEnv(log *logging.SimpleLogger, path string, env string, extraInitArgs []string, version *version.Version) ([]string, error)
+	RunInitAndWorkspace(log *logging.SimpleLogger, path string, env string, extraInitArgs []string, version *version.Version) ([]string, error)
 }
 
 type Client struct {

--- a/server/events/terraform/terraform_client.go
+++ b/server/events/terraform/terraform_client.go
@@ -72,7 +72,7 @@ func (c *Client) RunCommandWithVersion(log *logging.SimpleLogger, path string, a
 	// this is to support scripts to use the ENVIRONMENT, ATLANTIS_TERRAFORM_VERSION
 	// and WORKSPACE variables in their scripts
 	// append current process's environment variables
-	// this is to prevent the $PATH variable being removed from the environment
+	// this is to prevent the $PATH variable being removed from the environment.
 	envVars := []string{
 		fmt.Sprintf("ENVIRONMENT=%s", env),
 		fmt.Sprintf("ATLANTIS_TERRAFORM_VERSION=%s", v.String()),
@@ -113,7 +113,7 @@ func (c *Client) RunInitAndWorkspace(log *logging.SimpleLogger, path string, env
 	}
 
 	// Terraform uses 'terraform env' command for versions > 0.8 and < 0.10.
-	// Versions >= 0.10 use 'terraform workspace'
+	// Versions >= 0.10 use 'terraform workspace'.
 	workspaceCmdName := "workspace"
 	constraints, _ := version.NewConstraint("< 0.10.0")
 	if constraints.Check(v) {


### PR DESCRIPTION
We want to use `terraform workspace` for terraform versions >= `0.10.x`