### PR TITLE
check if err is nil before printing it

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -18,7 +18,9 @@ func (b *BootstrapCmd) Init() *cobra.Command {
 		Short: "Start a guided tour of Atlantis",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := bootstrap.Start()
-			fmt.Fprintf(os.Stderr, "\033[31mError: %s\033[39m\n\n", err.Error())
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "\033[31mError: %s\033[39m\n\n", err.Error())
+			}
 			return err
 		},
 	}


### PR DESCRIPTION
So I noticed that when exiting out of the bootstrap setup server using Ctrl-C, the script would throw a runtime error similar to this:

```
atlantis is running  [press Ctrl-c to exit]
⠋ ^C
shutdown signal received, exiting....

Thank you for using atlantis :)
For more information about how to use atlantis in production go to: https://github.com/hootsuite/atlantis
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1495947]

goroutine 1 [running]:
github.com/hootsuite/atlantis/cmd.(*BootstrapCmd).Init.func1(0xc4200a1440, 0x19295e8, 0x0, 0x0, 0x0, 0x0)
	/Users/umair/src/github.com/hootsuite/atlantis/cmd/bootstrap.go:21 +0x47
github.com/hootsuite/atlantis/vendor/github.com/spf13/cobra.(*Command).execute(0xc4200a1440, 0x19295e8, 0x0, 0x0, 0xc4200a1440, 0x19295e8)
	/Users/umair/src/github.com/hootsuite/atlantis/vendor/github.com/spf13/cobra/command.go:650 +0x456
github.com/hootsuite/atlantis/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x19028e0, 0x2, 0x4, 0x0)
	/Users/umair/src/github.com/hootsuite/atlantis/vendor/github.com/spf13/cobra/command.go:729 +0x2fe
github.com/hootsuite/atlantis/vendor/github.com/spf13/cobra.(*Command).Execute(0x19028e0, 0x1902a28, 0xc42010ff58)
	/Users/umair/src/github.com/hootsuite/atlantis/vendor/github.com/spf13/cobra/command.go:688 +0x2b
github.com/hootsuite/atlantis/cmd.Execute()
	/Users/umair/src/github.com/hootsuite/atlantis/cmd/root.go:17 +0x2d
main.main()
	/Users/umair/src/github.com/hootsuite/atlantis/main.go:21 +0x4b1
```

Took a bit of time to find it, but I think I found the solution. Turns out it was trying to dereference nil (`err.Error()`) which was the value of err in the case when a user hits Ctrl-C to exit of the server. 

With that small nil check added, it exited out of the bootstrap server a bit more gracefully.

Hope this helps and Atlantis looks great by the way! 👍 