### PR TITLE
When log-level is debug, print filename and line

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -106,7 +106,7 @@ func NewServer(config Config) (*Server, error) {
 		Locker:    lockingClient,
 		Workspace: workspace,
 	}
-	logger := logging.NewSimpleLogger("server", log.New(os.Stderr, "", log.LstdFlags), false, logging.ToLogLevel(config.LogLevel))
+	logger := logging.NewSimpleLogger("server", nil, false, logging.ToLogLevel(config.LogLevel))
 	eventParser := &events.EventParser{
 		GithubUser:  config.GithubUser,
 		GithubToken: config.GithubToken,


### PR DESCRIPTION
Before

```
atlantis server --gh-user skljk --gh-token sklj --log-level debug
2017/11/11 23:21:15 [WARN] server: Atlantis started - listening on port 4141
```

Now (see `server.go`)
```
atlantis server --gh-user skljk --gh-token sklj --log-level debug
2017/11/11 23:14:05 server.go:183: [WARN] server: Atlantis started - listening on port 4141
```

This only applies if log level is set to debug