### PR TITLE
Support changes in modules/ directories

### DIFF
--- a/server/events/project_finder_test.go
+++ b/server/events/project_finder_test.go
@@ -12,7 +12,7 @@ var noopLogger = logging.NewNoopLogger()
 var modifiedRepo = "owner/repo"
 var m = events.DefaultProjectFinder{}
 
-func TestGetModified_NoFiles(t *testing.T) {
+func TestGetModified(t *testing.T) {
 	cases := []struct {
 		description     string
 		files           []string
@@ -29,9 +29,19 @@ func TestGetModified_NoFiles(t *testing.T) {
 			nil,
 		},
 		{
-			"Should ignore .tf files in module directories",
-			[]string{"_modules/file.tf", "modules/file.tf", "parent/_modules/file.tf", "parent/modules/file.tf", "main.tf"},
+			"Should plan in the parent directory from modules",
+			[]string{"modules/file.tf"},
 			[]string{"."},
+		},
+		{
+			"Should plan in the parent directory from modules when module is in a subdir",
+			[]string{"modules/subdir/file.tf"},
+			[]string{"."},
+		},
+		{
+			"Should plan in the parent directory from modules when project is in its own dir",
+			[]string{"projectdir/modules/file.tf"},
+			[]string{"projectdir"},
 		},
 		{
 			"Should ignore tfstate files and return an empty list",


### PR DESCRIPTION
Fixes #188.

With this change, we'll detect changes in any directories under `modules/`. We'll then try to run `plan` one directory up from the `modules/` dir.

Examples:
* change to `modules/main.tf` will run plan in `.`
* change to `project/modules/main.tf` will run plan in `project/`
* change to `modules/dir/main.tf` will run plan in `.`

The only issue with this would be if a `modules` dir was being used between multiple projects, ex.
```
project1/
- main.tf # this references ../modules
project2/
- main.tf
modules/
- module.tf
```