### PR TITLE
Env fix. Release 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# v0.2.3
+## Features
+None
+
+## Bug Fixes
+* Use `env` instead of `workspace` for Terraform 0.9.*
+
+## Backwards Incompatibilities / Notes:
+None
+
+## Downloads
+* [atlantis_darwin_amd64.zip](https://github.com/hootsuite/atlantis/releases/download/v0.2.3/atlantis_darwin_amd64.zip)
+* [atlantis_linux_386.zip](https://github.com/hootsuite/atlantis/releases/download/v0.2.3/atlantis_linux_386.zip)
+* [atlantis_linux_amd64.zip](https://github.com/hootsuite/atlantis/releases/download/v0.2.3/atlantis_linux_amd64.zip)
+* [atlantis_linux_arm.zip](https://github.com/hootsuite/atlantis/releases/download/v0.2.3/atlantis_linux_arm.zip)
+
 # v0.2.2
 ## Features
 * Terraform 0.11 is now supported ([#219](https://github.com/hootsuite/atlantis/pull/219))

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	v := viper.New()
-	v.Set("version", "0.2.2")
+	v.Set("version", "0.2.3")
 
 	// We're creating commands manually here rather than using init() functions
 	// (as recommended by cobra) because it makes testing easier.

--- a/server/events/terraform/terraform_client.go
+++ b/server/events/terraform/terraform_client.go
@@ -118,10 +118,10 @@ func (c *DefaultClient) Init(log *logging.SimpleLogger, path string, workspace s
 		return outputs, err
 	}
 
-	// In 0.10 the env command was renamed to workspace.
 	workspaceCommand := "workspace"
 	if zeroPointNine.Check(version) {
-		workspaceCommand = "workspace"
+		// In 0.9.* `env` was used instead of `workspace`
+		workspaceCommand = "env"
 	}
 
 	output, err = c.RunCommandWithVersion(log, path, []string{workspaceCommand, "select", "-no-color", workspace}, version, workspace)


### PR DESCRIPTION
* fix bug where we were using `workspace` instead of `env`
* release 0.2.3