### PR TITLE
Update server.go

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -103,7 +103,7 @@ func NewServer(config Config) (*Server, error) {
 	if config.GitlabUser != "" {
 		supportedVCSHosts = append(supportedVCSHosts, vcs.Gitlab)
 		gitlabClient = &vcs.GitlabClient{
-			Client: gitlab.NewClient(nil, config.GitlabToken),
+			Client: gitlab.NewClient(config.GitlabHostname, config.GitlabToken),
 		}
 	}
 	var webhooksConfig []webhooks.Config


### PR DESCRIPTION
A "nil" always results in a default client. Not sure but the maybe custom specified GitlabHostname should be included here?