### PR TITLE
Use 'SetBaseURL' to correctly set GitLab URL based on user params.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -105,8 +105,13 @@ func NewServer(config Config) (*Server, error) {
 		gitlabClient = &vcs.GitlabClient{
 			Client: gitlab.NewClient(nil, config.GitlabToken),
 		}
-		err := gitlabClient.Client.SetBaseURL(config.GitlabHostname)
+		// Ensure the BaseURL has /api/v4/ appended. We only care about the Scheme
+		// and Host. GH-229
+		u, err := url.Parse(config.GitlabHostname)
 		if err != nil {
+			return nil, errors.Wrap(err, "parsing GitLab hostname")
+		}
+		if err := gitlabClient.Client.SetBaseURL(fmt.Sprintf("%s://%s/api/v4/", u.Scheme, u.Host)); err != nil {
 			return nil, err
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -105,7 +105,10 @@ func NewServer(config Config) (*Server, error) {
 		gitlabClient = &vcs.GitlabClient{
 			Client: gitlab.NewClient(nil, config.GitlabToken),
 		}
-		gitlabClient.Client.SetBaseURL(config.GitlabHostname)
+		err := gitlabClient.Client.SetBaseURL(config.GitlabHostname)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var webhooksConfig []webhooks.Config
 	for _, c := range config.Webhooks {

--- a/server/server.go
+++ b/server/server.go
@@ -105,6 +105,7 @@ func NewServer(config Config) (*Server, error) {
 		gitlabClient = &vcs.GitlabClient{
 			Client: gitlab.NewClient(nil, config.GitlabToken),
 		}
+		gitlabClient.Client.SetBaseURL(config.GitlabHostname)
 	}
 	var webhooksConfig []webhooks.Config
 	for _, c := range config.Webhooks {


### PR DESCRIPTION
This change updates server/server.go to set the GitLab URL using the `Client.SetBaseURL` to set the base URL off of the configured param. Previously even if a user set the `--gitlab-hostname`, the default URL for GitLab would not overridden to match this.

Tests run locally:
```
make test
?   	github.com/hootsuite/atlantis	[no test files]
?   	github.com/hootsuite/atlantis/bootstrap	[no test files]
ok  	github.com/hootsuite/atlantis/cmd	0.064s
ok  	github.com/hootsuite/atlantis/server	0.846s
ok  	github.com/hootsuite/atlantis/server/events	0.059s
ok  	github.com/hootsuite/atlantis/server/events/locking	0.010s
ok  	github.com/hootsuite/atlantis/server/events/locking/boltdb	0.121s
?   	github.com/hootsuite/atlantis/server/events/locking/mocks	[no test files]
?   	github.com/hootsuite/atlantis/server/events/locking/mocks/matchers	[no test files]
?   	github.com/hootsuite/atlantis/server/events/mocks	[no test files]
?   	github.com/hootsuite/atlantis/server/events/mocks/matchers	[no test files]
?   	github.com/hootsuite/atlantis/server/events/models	[no test files]
?   	github.com/hootsuite/atlantis/server/events/models/fixtures	[no test files]
ok  	github.com/hootsuite/atlantis/server/events/run	0.160s
?   	github.com/hootsuite/atlantis/server/events/run/mocks	[no test files]
?   	github.com/hootsuite/atlantis/server/events/run/mocks/matchers	[no test files]
ok  	github.com/hootsuite/atlantis/server/events/terraform	0.010s
?   	github.com/hootsuite/atlantis/server/events/terraform/mocks	[no test files]
?   	github.com/hootsuite/atlantis/server/events/terraform/mocks/matchers	[no test files]
ok  	github.com/hootsuite/atlantis/server/events/vcs	0.013s [no tests to run]
?   	github.com/hootsuite/atlantis/server/events/vcs/fixtures	[no test files]
?   	github.com/hootsuite/atlantis/server/events/vcs/mocks	[no test files]
?   	github.com/hootsuite/atlantis/server/events/vcs/mocks/matchers	[no test files]
ok  	github.com/hootsuite/atlantis/server/events/webhooks	0.014s
?   	github.com/hootsuite/atlantis/server/events/webhooks/mocks	[no test files]
?   	github.com/hootsuite/atlantis/server/events/webhooks/mocks/matchers	[no test files]
ok  	github.com/hootsuite/atlantis/server/logging	0.011s [no tests to run]
?   	github.com/hootsuite/atlantis/server/logging/mocks	[no test files]
?   	github.com/hootsuite/atlantis/server/logging/mocks/matchers	[no test files]
?   	github.com/hootsuite/atlantis/server/mocks	[no test files]
?   	github.com/hootsuite/atlantis/server/mocks/matchers	[no test files]
ok  	github.com/hootsuite/atlantis/server/recovery	0.011s [no tests to run]
?   	github.com/hootsuite/atlantis/testing	[no test files]
```

Closes #227