### PR TITLE
PreExecutor - working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,10 +209,10 @@ extra_arguments:
 ```
 
 When running the `pre_plan`, `post_plan`, `pre_apply`, and `post_apply` commands the following environment variables are available
-- `ENVIRONMENT`: if an environment argument is supplied to `atlantis plan` or `atlantis apply` this will
+- `WORKSPACE`: if an environment argument is supplied to `atlantis plan` or `atlantis apply` this will
 be the value of that argument. Else it will be `default`
 - `ATLANTIS_TERRAFORM_VERSION`: local version of `terraform` or the version from `terraform_version` if specified, ex. `0.10.0`
-- `WORKSPACE`: absolute path to the root of the project on disk
+- `DIR`: absolute path to the root of the project on disk
 
 ## Locking
 When `plan` is run, the [project](#project) and [workspace](#workspaceenvironment) are **Locked** until an `apply` succeeds **and** the pull request/merge request is merged.

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ extra_arguments:
 ```
 
 When running the `pre_plan`, `post_plan`, `pre_apply`, and `post_apply` commands the following environment variables are available
-- `WORKSPACE`: if an environment argument is supplied to `atlantis plan` or `atlantis apply` this will
+- `WORKSPACE`: if a workspace argument is supplied to `atlantis plan` or `atlantis apply`, ex `atlantis plan staging`, this will
 be the value of that argument. Else it will be `default`
 - `ATLANTIS_TERRAFORM_VERSION`: local version of `terraform` or the version from `terraform_version` if specified, ex. `0.10.0`
 - `DIR`: absolute path to the root of the project on disk


### PR DESCRIPTION
## Issue

Seems pre-executor is not setting the working directory for the supplied script, this behaviour is not consistent with how the Terraform client executes in project working directory:

https://github.com/hootsuite/atlantis/blob/002980e423b239c7ec624af73d50cc906f0fa9ad/server/events/terraform/terraform_client.go#L90-L92

Also, the pre-plan environment variable names were changed to match terraform terminology some time back, but the README still has the old variable names

## Proposed fixes

- [x] Update pre-plan environment variable names in README 

https://github.com/hootsuite/atlantis/blob/7c1220a655673a77e9555f79f4069a60bcdf2bc1/server/events/run/run.go#L53-L56

- [ ] Set `Dir` field on `exec.Command` to ensure scripts ran by PreExecutor run in absolute path

https://github.com/hootsuite/atlantis/blob/7c1220a655673a77e9555f79f4069a60bcdf2bc1/server/events/run/run.go#L89-L98

Alternatively, documentation should highlight that no working directory is set for `pre` scripts
