### PR TITLE
Set as_user to true for slack post message function

### DIFF
--- a/server/events/webhooks/slack_client.go
+++ b/server/events/webhooks/slack_client.go
@@ -68,7 +68,7 @@ func (d *DefaultSlackClient) ChannelExists(channelName string) (bool, error) {
 func (d *DefaultSlackClient) PostMessage(channel string, applyResult ApplyResult) error {
 	params := slack.NewPostMessageParameters()
 	params.Attachments = d.createAttachments(applyResult)
-        params.AsUser = true
+    params.AsUser = true
 	params.EscapeText = false
 	_, _, err := d.Slack.PostMessage(channel, "", params)
 	return err

--- a/server/events/webhooks/slack_client.go
+++ b/server/events/webhooks/slack_client.go
@@ -68,6 +68,7 @@ func (d *DefaultSlackClient) ChannelExists(channelName string) (bool, error) {
 func (d *DefaultSlackClient) PostMessage(channel string, applyResult ApplyResult) error {
 	params := slack.NewPostMessageParameters()
 	params.Attachments = d.createAttachments(applyResult)
+        params.AsUser = true
 	params.EscapeText = false
 	_, _, err := d.Slack.PostMessage(channel, "", params)
 	return err
@@ -103,3 +104,4 @@ func (d *DefaultSlackClient) createAttachments(applyResult ApplyResult) []slack.
 	}
 	return []slack.Attachment{attachment}
 }
+

--- a/server/events/webhooks/slack_client.go
+++ b/server/events/webhooks/slack_client.go
@@ -68,7 +68,7 @@ func (d *DefaultSlackClient) ChannelExists(channelName string) (bool, error) {
 func (d *DefaultSlackClient) PostMessage(channel string, applyResult ApplyResult) error {
 	params := slack.NewPostMessageParameters()
 	params.Attachments = d.createAttachments(applyResult)
-    params.AsUser = true
+	params.AsUser = true
 	params.EscapeText = false
 	_, _, err := d.Slack.PostMessage(channel, "", params)
 	return err

--- a/server/events/webhooks/slack_client.go
+++ b/server/events/webhooks/slack_client.go
@@ -104,4 +104,3 @@ func (d *DefaultSlackClient) createAttachments(applyResult ApplyResult) []slack.
 	}
 	return []slack.Attachment{attachment}
 }
-

--- a/server/events/webhooks/slack_client_test.go
+++ b/server/events/webhooks/slack_client_test.go
@@ -169,4 +169,3 @@ func setup(t *testing.T) {
 		Success: true,
 	}
 }
-

--- a/server/events/webhooks/slack_client_test.go
+++ b/server/events/webhooks/slack_client_test.go
@@ -98,7 +98,7 @@ func TestPostMessage_Success(t *testing.T) {
 			},
 		},
 	}}
-	expParams.AsUser = false
+	expParams.AsUser = true
 	expParams.EscapeText = false
 
 	channel := "somechannel"
@@ -137,7 +137,7 @@ func TestPostMessage_Error(t *testing.T) {
 			},
 		},
 	}}
-	expParams.AsUser = false
+	expParams.AsUser = true
 	expParams.EscapeText = false
 
 	channel := "somechannel"
@@ -169,3 +169,4 @@ func setup(t *testing.T) {
 		Success: true,
 	}
 }
+


### PR DESCRIPTION
Set as_user to true for slack post message function so messages to a Slack channel use the bot's name and icon. 